### PR TITLE
Feature/auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
       <h3>Welcome To Mandooo Shop!</h3>
       <span>안녕하세요👋🏻 로그인 하시면 여기에 닉네임이 뜰거에요!</span>
 
-      <a class="loginBtn">로그인</a>
+      <a class="loginBtn" href="./login/index.html">로그인</a>
     </main>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,15 +17,18 @@
           <li><a href="./index.html">Home</a></li>
           <li><a href="./products.html">Products</a></li>
           <li><a href="./cart.html">Cart</a></li>
+          <li><a href="./login/index.html" id="headerLoginLi">Login</a></li>
         </ul>
       </nav>
     </header>
 
     <main class="home">
       <h3>Welcome To Mandooo Shop!</h3>
-      <span>안녕하세요👋🏻 로그인 하시면 여기에 닉네임이 뜰거에요!</span>
+      <span id="namespan"
+        >안녕하세요👋🏻 로그인 하시면 여기에 닉네임이 뜰거에요!</span
+      >
 
-      <a class="loginBtn" href="./login/index.html">로그인</a>
+      <a id="loginBtn" href="./login/index.html">로그인</a>
     </main>
   </body>
 </html>

--- a/login/index.html
+++ b/login/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../reset.css" />
+    <link rel="stylesheet" href="./style.css" />
+    <script defer type="module" src="./script.js"></script>
+    <title>Document</title>
+  </head>
+  <body>
+    <main>
+      <h1>Login</h1>
+      <form>
+        <div class="inputbox">
+          <label for="inputLoginId">ID</label>
+          <input
+            type="text"
+            id="inputLoginId"
+            placeholder="아이디를 입력하세요"
+          />
+        </div>
+        <div class="inputbox">
+          <label for="inputLoginPw">PW</label>
+          <input
+            type="password"
+            id="inputLoginPw"
+            placeholder="비밀번호를 입력하세요"
+          />
+        </div>
+        <div class="inputbox" id="chkbox">
+          <label for="rememberId">아이디 저장하기</label>
+          <input type="checkbox" id="rememberId" />
+        </div>
+      </form>
+      <nav class="loginBtnNav">
+        <button id="login">Login</button>
+        <a href="../signup/index.html">Sign Up</a>
+        <a href="../index.html">Back</a>
+      </nav>
+    </main>
+  </body>
+</html>

--- a/login/script.js
+++ b/login/script.js
@@ -1,0 +1,61 @@
+const inputLoginId = document.getElementById("inputLoginId");
+const inputLoginPw = document.getElementById("inputLoginPw");
+const loginBtn = document.getElementById("login");
+const rememberIdChk = document.getElementById("rememberId");
+
+const signupUserInfos = JSON.parse(localStorage.getItem("signupUserInfo"));
+const savedUserId = localStorage.getItem("savedUserId");
+console.log(savedUserId);
+
+if(!signupUserInfos){
+  alert("해당 정보로 가입된 회원이 없습니다. 회원가입 페이지로 이동합니다.");
+  location.href = "../signup/index.html";
+}
+
+let [loginId, loginPw] = ["", ""];
+
+if(savedUserId){
+  alert("이전에 저장한 아이디를 불러옵니다.");
+  loginId = savedUserId;
+  inputLoginId.value = savedUserId;
+  inputLoginPw.focus();
+}
+
+
+inputLoginId.addEventListener("change", e => {
+  loginId = e.target.value;
+});
+
+inputLoginPw.addEventListener("change", e => {
+  loginPw = e.target.value;
+});
+
+loginBtn.addEventListener("click", () => {
+  if(loginId === ""){
+    alert("아이디를 입력해주세요");
+    inputLoginId.focus();
+    return;
+  }
+
+  if(loginPw === ""){
+    alert("비밀번호를 입력해주세요");
+    inputLoginPw.focus();
+    return;
+  }
+
+  if(loginId !== "" && loginPw !== "" && !(signupUserInfos.some(user => user.id === loginId && user.pw === loginPw))){
+    alert("입력한 아이디 또는 비밀번호가 일치하지 않습니다");
+    inputLoginId.focus();
+    return;
+  }
+
+  // 아이디 저장하기
+  rememberIdChk ? localStorage.setItem("savedUserId", loginId) : localStorage.removeItem("savedUserId");
+  
+
+  // isLogin으로 탭 껐다 켜도 로그인 유지
+  const isLogin = signupUserInfos.find(user => user.id === loginId);
+  localStorage.setItem("isLogin", JSON.stringify(isLogin));
+  alert(`${signupUserInfos.filter((user) => user.id === loginId)[0].username}님 환영합니다!`);
+  location.href = "../index.html";
+})

--- a/login/style.css
+++ b/login/style.css
@@ -1,0 +1,93 @@
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+main {
+  /* flex 설정 */
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  /* 크기 여백 설정 */
+  width: 50%;
+  height: 50%;
+  padding: 10px;
+
+  /* 기타 설정 */
+  border: 1px solid gray;
+  border-radius: 3px;
+  box-shadow: 2px 2px rgba(44, 24, 24, 0.5);
+}
+
+h1 {
+  font-size: 30px;
+  margin-bottom: 20px;
+  color: black;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 80%;
+}
+
+.inputbox {
+  padding: 10px;
+  width: 90%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+label {
+  color: black;
+  min-width: fit-content;
+}
+
+.inputbox > input {
+  width: 80%;
+  padding: 10px;
+  border: 1px solid gray;
+  margin: 10px 0;
+}
+
+#chkbox {
+  justify-content: center;
+}
+
+.inputbox > .rememberId {
+  align-items: right;
+}
+
+.loginBtnNav {
+  margin: 10px 0;
+}
+
+.loginBtnNav > button {
+  display: inline-block;
+  font-size: 15px;
+  margin: 0 10px;
+  padding: 5px;
+  border-radius: 5px;
+  border: none;
+  background-color: royalblue;
+  color: white;
+  cursor: pointer;
+}
+
+.loginBtnNav > a {
+  display: inline-block;
+  margin: 0 10px;
+  text-decoration: none;
+  color: black;
+}
+
+.loginBtnNav > a:hover, :active {
+  color: royalblue;
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,25 @@
+const headerLogin = document.getElementById("headerLoginLi");
+const mainLogin = document.getElementById("loginBtn");
+
+const isLogin = JSON.parse(localStorage.getItem("isLogin"));
+const signupUserInfos = JSON.parse(localStorage.getItem("signupUserInfo"));
+
+// 로그인 되어있으면 로그아웃으로 갈 수 있게
+if(isLogin){
+  mainLogin.style.display = "none";
+  headerLogin.innerText = "Logout";
+  headerLogin.href = "";
+
+  headerLogin.addEventListener("click", () => {
+    localStorage.removeItem("isLogin");
+    window.location.reload();
+  });
+}
+
+const namespan = document.getElementById("namespan");
+namespan.innerText = isLogin ? `안녕하세요👋🏻 ${isLogin.username}님!` : `안녕하세요👋🏻 로그인 하시면 여기에 닉네임이 뜰거에요!`;
+
+headerLogin.addEventListener("click", () => {
+  localStorage.removeItem("isLogin");
+  window.location.reload();
+})

--- a/signup/index.html
+++ b/signup/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign up</title>
+    <link rel="stylesheet" href="../reset.css" />
+    <link rel="stylesheet" href="../signup/style.css" />
+    <script defer type="module" src="../signup/script.js"></script>
+  </head>
+  <body>
+    <main>
+      <h1>Sign up</h1>
+      <form>
+        <input type="text" id="inputUserId" placeholder="ID" />
+        <input type="password" id="inputUserPw" placeholder="Password" />
+        <input
+          type="text"
+          id="inputUserName"
+          placeholder="Write your username"
+        />
+      </form>
+      <nav class="signupBtnNav">
+        <button id="signup" class="movePage">Sign up</button>
+        <a href="../login/index.html">Back</a>
+        <a href="../index.html">Go Home</a>
+      </nav>
+    </main>
+  </body>
+</html>

--- a/signup/script.js
+++ b/signup/script.js
@@ -1,0 +1,82 @@
+const inputUserId = document.getElementById("inputUserId");
+const inputUserPw = document.getElementById("inputUserPw");
+const inputUserName = document.getElementById("inputUserName");
+const signupBtn = document.getElementById("signup");
+
+// 회원가입하는 유저 정보
+let signupUserInfo = {
+  id: "",
+  pw: "",
+  username: "",
+
+  setId(v){
+    if(v.length < 6){
+      alert("입력받은 ID가 6자 이하입니다. 다시 입력해주세요");
+      inputUserId.value = ""
+      inputUserId.focus();
+      return;
+    } 
+    this.id = v;
+  },
+
+  setPw(v) {
+    if(v.length < 8){
+      alert("입력받은 PW가 8자 이하입니다. 다시 입력해주세요");
+      inputUserPw.value = ""
+      inputUserPw.focus();
+      return;
+    }
+    this.pw = v;
+  },
+
+  setUserName(v) {
+    console.log(v);
+    this.username = v;
+  },
+};
+
+// 입력받은 정보 set
+inputUserId.addEventListener("change", e => {
+  signupUserInfo.setId(e.target.value);
+});
+
+inputUserPw.addEventListener("change", e => {
+  signupUserInfo.setPw(e.target.value);
+})
+
+inputUserName.addEventListener("change", e => {
+  signupUserInfo.setUserName(e.target.value);
+});
+
+// 공백값 체크
+signupBtn.addEventListener("click", () => {
+  if(signupUserInfo.id === ""){
+    alert("아이디가 입력되지 않았습니다. 아이디를 입력하세요");
+    inputUserId.focus();
+    return;
+  }
+
+  if(signupUserInfo.pw === ""){
+    alert("비밀번호가 입력되지 않았습니다. 비밀번호를 입력하세요");
+    inputUserPw.focus();
+    return;
+  }
+
+  if(signupUserInfo.username === ""){
+    alert("사용자 이름이 입력되지 않았습니다. 이름을 입력하세요");
+    inputUserName.focus();
+    return;
+  }
+
+  // 회원가입 확인
+  const isConfirm = confirm(`id => ${signupUserInfo.id} \npw => ${signupUserInfo.pw} \nname => ${signupUserInfo.username} \n입력하신 정보가 정확한지 확인해주세요`);
+  
+  if(isConfirm){
+    alert("회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.");
+    localStorage.setItem("signupUserInfo", JSON.stringify(signupUserInfo));
+    location.href="../login/index.html";
+  } else {
+    alert("회원가입에 실패했습니다.");
+  }
+
+})

--- a/signup/script.js
+++ b/signup/script.js
@@ -73,7 +73,9 @@ signupBtn.addEventListener("click", () => {
   
   if(isConfirm){
     alert("회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.");
-    localStorage.setItem("signupUserInfo", JSON.stringify(signupUserInfo));
+    const userInfo = JSON.parse(localStorage.getItem("signupUserInfo")) ?? [];
+    const newUserInfo = [...userInfo, signupUserInfo]
+    localStorage.setItem("signupUserInfo", JSON.stringify(newUserInfo));
     location.href="../login/index.html";
   } else {
     alert("회원가입에 실패했습니다.");

--- a/signup/style.css
+++ b/signup/style.css
@@ -1,0 +1,72 @@
+body {
+  display: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+main {
+  /* flex 설정 */
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  /* 크기 여백 설정 */
+  width: 50%;
+  height: 50%;
+  padding: 10px;
+
+  /* 기타 설정 */
+  border: 1px solid gray;
+  border-radius: 3px;
+  box-shadow: 2px 2px rgba(44, 24, 24, 0.5);
+}
+
+/* signup text 설정 */
+h1 {
+  font-size: 30px;
+  margin-bottom: 20px;
+  color: black;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 80%;
+}
+
+input {
+  padding: 10px;
+  border: 1px solid gray;
+  margin: 10px 0;
+}
+
+.signupBtnNav {
+  margin: 10px 0;
+}
+
+.signupBtnNav > button {
+  display: inline-block;
+  font-size: 15px;
+  margin: 0 10px;
+  padding: 5px;
+  border-radius: 5px;
+  border: none;
+  background-color: royalblue;
+  color: white;
+  cursor: pointer;
+}
+
+.signupBtnNav > a {
+  display: inline-block;
+  margin: 0 10px;
+  text-decoration: none;
+  color: black;
+}
+
+.signupBtnNav > a:hover, :active {
+  color: royalblue;
+}

--- a/style.css
+++ b/style.css
@@ -59,7 +59,7 @@ a:active {
   margin-bottom: 20px;
 }
 
-.home > .loginBtn {
+.home > #loginBtn {
   display: inline-block;
   padding: 10px 20px;
   margin-top: 100px;


### PR DESCRIPTION
## 작성자

> 최가은

## 구현 내용

> 1. `회원가입`
- 회원가입하는 유저의 ID, PW, NAME 입력 -> ID가 6자 이하면 재입력, PW가 8자 이하면 재입력 요청
- 회원가입하는 유저의 ID, PW, NAME 저장후 설정
- 회원가입 버튼을 눌렀을 때 저장한 값이 공백인 경우 재입력 요청(focus)
- 회원가입 정보 alert로 확인 후 회원가입 성공시 login/lndex.html로 리다이렉트
- (개인적 기능 추가) 다수의 유저 생성 가능

> 2. `로그인`
- 회원가입되어있는 유저가 없다면 signup/index.html로 리다이렉트
- 로그인하는 유저의 ID, PW 입력 -> 로그인 버튼을 눌렀을 때 공백이 있는 경우 재입력 요청(focus)
- 입력받은 ID, PW값과 회원가입 되어있는 유저의 ID, PW값 비교후 일치 여부 확인
- 아이디 저장하기 체크박스를 선택한 경우 localStorage(savedUserId)에 입력받은 ID 저장
- 로그아웃 후 재로그인을 할 때 localStorage에 있던 아이디 값(savedUserId)를 ID 입력 필드에 셋팅
- 로그인에 성공할 경우 localStorage(isLogin)을 통해 탭을 껐다 켜도 로그인 유지

> 3. `로그아웃`
- 로그인에서 받은 `isLogin`에 값이 있다면 상단에 Login버튼 Logout으로 변경, 메인 페이지에 Login버튼 숨기기
- 현재 로그인한 유저의 NAME을 span에 띄우기

### 스크린샷 (선택)
1. signup
![signup](https://github.com/user-attachments/assets/648e631e-f597-4ffe-9688-cce0a47a56b0)

2. login 
![login](https://github.com/user-attachments/assets/82658713-a38a-4172-afe6-6e1df5d57560)

3. logout
![logout](https://github.com/user-attachments/assets/942a30da-f43a-4ef8-95ba-eb469d75c556)


